### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
           if [[ "${{ github.event_name }}" = "release" ]]; then
             target="ps5-mqtt"
           fi
-          echo "target=${target}" >> $GITHUB_OUTPUT
+          echo "target=${target}" >> "$GITHUB_OUTPUT"
       - name: ⏭ Copy add-on files
         run: |
           cp add-ons/common/Dockerfile add-ons/${{ steps.prepare.outputs.target }}
@@ -64,8 +64,8 @@ jobs:
             version="${version#v}"
             environment="stable"
           fi
-          echo "environment=${environment}" >> $GITHUB_OUTPUT
-          echo "version=${version}" >> $GITHUB_OUTPUT
+          echo "environment=${environment}" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
 
   deploy:
     name: 👷 Build & Deploy ${{ matrix.arch }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
           if [[ "${{ github.event_name }}" = "release" ]]; then
             target="ps5-mqtt"
           fi
-          echo "::set-output name=target::${target}"
+          echo "target=${target}" >> $GITHUB_OUTPUT
       - name: ⏭ Copy add-on files
         run: |
           cp add-ons/common/Dockerfile add-ons/${{ steps.prepare.outputs.target }}
@@ -64,8 +64,8 @@ jobs:
             version="${version#v}"
             environment="stable"
           fi
-          echo "::set-output name=environment::${environment}"
-          echo "::set-output name=version::${version}"
+          echo "environment=${environment}" >> $GITHUB_OUTPUT
+          echo "version=${version}" >> $GITHUB_OUTPUT
 
   deploy:
     name: 👷 Build & Deploy ${{ matrix.arch }}


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


