### PR TITLE
Fix Debug Logging

### DIFF
--- a/ps5-mqtt/server/src/index.ts
+++ b/ps5-mqtt/server/src/index.ts
@@ -19,7 +19,7 @@ import { MQTT_CLIENT, Settings, SETTINGS } from "./services";
 import { createErrorLogger } from "./util/error-logger";
 import { setupWebserver } from "./web-server";
 
-const debug = createDebugger("@ha:ps5");
+const debug = createDebugger("@ha:ps5:debug");
 const debugMqtt = createDebugger("@ha:ps5:mqtt");
 const debugState = createDebugger("@ha:state");
 const logError = createErrorLogger();


### PR DESCRIPTION
This change is to make the debug filter work properly. If you filter on @ha:ps5:*, normal debug messages using the debug logger are not captured. This change renames the main debugger so it is picked up by this filter.