### PR TITLE
Add discovery_topic option, descriptive error when stdout empty

### DIFF
--- a/add-ons/ps5-mqtt-edge/DOCS.md
+++ b/add-ons/ps5-mqtt-edge/DOCS.md
@@ -24,13 +24,17 @@ account_check_interval: 5000        # Recommended interval for checking account 
 ### `mqtt` *optional*
 Optional [MQTT][mqtt-broker] connection information. 
 
+
 If no information was provided the connection information will be acquired automatically.
+
+**If you don't use the default Home Assistant discovery topic (i.e., "homeassistant"), you MUST set the `discovery_topic` to your custom discovery topic as this cannot be acquired automatically.**
 
 ```yaml
 host: 192.168.0.2                   # (ip)address of your mqtt broker
 port: '1883'                        # port of your mqtt broker
 user: mqttuser                      # username used for connecting to your mqtt broker
 pass: somepassword                  # password used for connecting to your mqtt broker
+discovery_topic: custom_topic       # Home Assistant discovery topic. Must be set if you've changed the discovery topic in Home Assistant. Default: homeassistant 
 ``` 
 
 ### `logger`

--- a/add-ons/ps5-mqtt-edge/config.yaml
+++ b/add-ons/ps5-mqtt-edge/config.yaml
@@ -37,6 +37,7 @@ schema:
     port: port?
     user: str?
     pass: str?
+    discovery_topic: str?
   psn_accounts:
     - username: str?
       npsso: str

--- a/add-ons/ps5-mqtt/DOCS.md
+++ b/add-ons/ps5-mqtt/DOCS.md
@@ -26,11 +26,14 @@ Optional [MQTT][mqtt-broker] connection information.
 
 If no information was provided the connection information will be acquired automatically.
 
+**If you don't use the default Home Assistant discovery topic (i.e., "homeassistant"), you MUST set the `discovery_topic` to your custom discovery topic as this cannot be acquired automatically.**
+
 ```yaml
 host: 192.168.0.2                   # (ip)address of your mqtt broker
 port: '1883'                        # port of your mqtt broker
 user: mqttuser                      # username used for connecting to your mqtt broker
 pass: somepassword                  # password used for connecting to your mqtt broker
+discovery_topic: custom_topic       # Home Assistant discovery topic. Must be set if you've changed the discovery topic in Home Assistant. Default: homeassistant 
 ``` 
 
 ### `logger`

--- a/add-ons/ps5-mqtt/config.yaml
+++ b/add-ons/ps5-mqtt/config.yaml
@@ -37,6 +37,7 @@ schema:
     port: port?
     user: str?
     pass: str?
+    discovery_topic: str?
   psn_accounts:
     - username: str?
       npsso: str

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -50,6 +50,7 @@ services:
       - MQTT_PORT=1883                                  # port of your mqtt broker
       - MQTT_USERNAME=mqttuser                          # username used for connecting to your mqtt broker
       - MQTT_PASSWORD=mqttpassword                      # password used for connecting to your mqtt broker
+      - DISCOVERY_TOPIC=your_custom_discovery_topic     # Home Assistant discovery topic. Only needs to be set if you've changed the discovery topic in Home Assistant. Default: homeassistant
 
       - DEVICE_CHECK_INTERVAL=5000
       - DEVICE_DISCOVERY_INTERVAL=60000
@@ -90,7 +91,8 @@ services:
       "host": "192.168.0.132",
       "port": "1883",
       "user": "mqttuser",
-      "pass": "mqttpassword"
+      "pass": "mqttpassword",
+      "discovery_topic": "your_custom_discovery_topic"
   },
 
   "device_check_interval": 5000,

--- a/ps5-mqtt/server/src/config.test.ts
+++ b/ps5-mqtt/server/src/config.test.ts
@@ -22,7 +22,8 @@ describe("Configuration", () => {
                 host: 'core-mosquitto',
                 port: '1883',
                 pass: 'REDACTED',
-                user: 'addons'
+                user: 'addons',
+                discovery_topic: 'homeassistant'
             },
             logger: '@ha:ps5:*,@ha:ps5-sensitive:*',
             device_check_interval: 5000,
@@ -47,7 +48,8 @@ describe("Configuration", () => {
                 host: 'core-mosquitto',
                 port: '1883',
                 pass: 'REDACTED',
-                user: 'addons'
+                user: 'addons',
+                discovery_topic: 'homeassistant'
             },
             logger: '@ha:ps5:*,@ha:ps5-sensitive:*',
             device_check_interval: 5000,
@@ -76,7 +78,8 @@ describe("Configuration", () => {
                 host: 'core-mosquitto',
                 port: '1883',
                 pass: 'REDACTED',
-                user: 'addons'
+                user: 'addons',
+                discovery_topic: 'homeassistant'
             },
             logger: '@ha:ps5:*,@ha:ps5-sensitive:*',
             device_check_interval: 5000,
@@ -99,7 +102,8 @@ describe("Configuration", () => {
                 host: 'core-mosquitto',
                 port: '1883',
                 pass: 'REDACTED',
-                user: 'addons'
+                user: 'addons',
+                discovery_topic: 'homeassistant'
             },
             logger: '@ha:ps5:*,@ha:ps5-sensitive:*',
             device_check_interval: 5000,

--- a/ps5-mqtt/server/src/config.ts
+++ b/ps5-mqtt/server/src/config.ts
@@ -40,6 +40,7 @@ export module AppConfig {
         pass: string;
         port: string;
         user: string;
+        discovery_topic: string;
     }
 
     export interface MqttConfig {
@@ -47,6 +48,7 @@ export module AppConfig {
         pass: string;
         port: string;
         user: string;
+        discovery_topic: string;
     }
 }
 
@@ -83,6 +85,7 @@ function getEnvConfig(): Partial<AppConfig> {
         MQTT_PASSWORD,
         MQTT_PORT,
         MQTT_USERNAME,
+        DISCOVERY_TOPIC,
 
         FRONTEND_PORT,
 
@@ -105,6 +108,7 @@ function getEnvConfig(): Partial<AppConfig> {
             port: MQTT_PORT,
             pass: MQTT_PASSWORD,
             user: MQTT_USERNAME,
+            discovery_topic: DISCOVERY_TOPIC,
         },
 
         device_check_interval:

--- a/ps5-mqtt/server/src/config.ts
+++ b/ps5-mqtt/server/src/config.ts
@@ -108,7 +108,7 @@ function getEnvConfig(): Partial<AppConfig> {
             port: MQTT_PORT,
             pass: MQTT_PASSWORD,
             user: MQTT_USERNAME,
-            discovery_topic: DISCOVERY_TOPIC,
+            discovery_topic: DISCOVERY_TOPIC || "homeassistant",
         },
 
         device_check_interval:

--- a/ps5-mqtt/server/src/index.ts
+++ b/ps5-mqtt/server/src/index.ts
@@ -79,7 +79,9 @@ async function run() {
             ?? path.join(os.homedir(), '.config', 'playactor', 'credentials.json'),
         allowPs4Devices: appConfig.include_ps4_devices ?? true,
 
-        deviceDiscoveryBroadcastAddress: appConfig.device_discovery_broadcast_address
+        deviceDiscoveryBroadcastAddress: appConfig.device_discovery_broadcast_address,
+
+        discoveryTopic: appConfig.mqtt.discovery_topic,
     };
 
     try {

--- a/ps5-mqtt/server/src/redux/sagas/check-devices-state.ts
+++ b/ps5-mqtt/server/src/redux/sagas/check-devices-state.ts
@@ -28,6 +28,11 @@ function* checkDevicesState() {
                 throw new Error(stderr)
             }
 
+            if (!stdout) {
+                throw new Error("No data received from Playstation. If this error continues, " +
+                                "your Playstation is likely powered off and will not be available until it is in either rest mode or powered on.");
+            }
+        
             const updatedDevice: Device = JSON.parse(stdout);
 
             if (

--- a/ps5-mqtt/server/src/redux/sagas/check-devices-state.ts
+++ b/ps5-mqtt/server/src/redux/sagas/check-devices-state.ts
@@ -29,8 +29,9 @@ function* checkDevicesState() {
             }
 
             if (!stdout) {
-                throw new Error("No data received from Playstation. If this error continues, " +
-                                "your Playstation is likely powered off and will not be available until it is in either rest mode or powered on.");
+                throw "No data received from Playstation. If this error continues, " +
+                    "your Playstation is likely powered off or unreachable - it will " +
+                    "not be available until it is in either rest mode/powered on and reachable.";
             }
         
             const updatedDevice: Device = JSON.parse(stdout);

--- a/ps5-mqtt/server/src/redux/sagas/register-device.ts
+++ b/ps5-mqtt/server/src/redux/sagas/register-device.ts
@@ -4,6 +4,9 @@ import { MQTT_CLIENT } from "../../services";
 import { HaMqtt } from "../../util/ha-mqtt";
 import { addDevice, updateHomeAssistant } from "../action-creators";
 import type { RegisterDeviceAction } from "../types";
+import { getAppConfig } from "../../config";
+
+const appConfig = getAppConfig();
 
 function* registerDevice(
     { payload: device }: RegisterDeviceAction
@@ -11,6 +14,8 @@ function* registerDevice(
     const mqtt: MQTT.AsyncClient = yield getContext(MQTT_CLIENT);
 
     const deviceConfig = HaMqtt.getMqttDeviceConfig(device);
+
+    const discoveryTopic: string = appConfig.mqtt.discovery_topic || "homeassistant";
 
     yield call<
         (
@@ -20,7 +25,7 @@ function* registerDevice(
         ) => Promise<MQTT.IPublishPacket>
     >(
         mqtt.publish.bind(mqtt),
-        `homeassistant/switch/${device.id}/power/config`,
+        `${discoveryTopic}/switch/${device.id}/power/config`,
         // https://www.home-assistant.io/integrations/switch.mqtt/
         JSON.stringify(<HaMqtt.Config.MqttSwitchEntity>{
             availability: [
@@ -53,7 +58,7 @@ function* registerDevice(
         ) => Promise<MQTT.IPublishPacket>
     >(
         mqtt.publish.bind(mqtt),
-        `homeassistant/sensor/${device.id}/activity/config`,
+        `${discoveryTopic}/sensor/${device.id}/activity/config`,
         JSON.stringify(<HaMqtt.Config.MqttSensorEntity>{
             availability: [
                 {

--- a/ps5-mqtt/server/src/redux/sagas/register-device.ts
+++ b/ps5-mqtt/server/src/redux/sagas/register-device.ts
@@ -1,21 +1,18 @@
 import type MQTT from "async-mqtt";
 import { call, getContext, put } from "redux-saga/effects";
-import { MQTT_CLIENT } from "../../services";
+
+import { MQTT_CLIENT, SETTINGS, Settings } from "../../services";
 import { HaMqtt } from "../../util/ha-mqtt";
 import { addDevice, updateHomeAssistant } from "../action-creators";
 import type { RegisterDeviceAction } from "../types";
-import { getAppConfig } from "../../config";
-
-const appConfig = getAppConfig();
 
 function* registerDevice(
     { payload: device }: RegisterDeviceAction
 ) {
     const mqtt: MQTT.AsyncClient = yield getContext(MQTT_CLIENT);
+    const { discoveryTopic }: Settings = yield getContext(SETTINGS);
 
     const deviceConfig = HaMqtt.getMqttDeviceConfig(device);
-
-    const discoveryTopic: string = appConfig.mqtt.discovery_topic || "homeassistant";
 
     yield call<
         (

--- a/ps5-mqtt/server/src/services.ts
+++ b/ps5-mqtt/server/src/services.ts
@@ -11,4 +11,6 @@ export interface Settings {
     allowPs4Devices: boolean;
 
     deviceDiscoveryBroadcastAddress: string;
+
+    discoveryTopic: string;
 }


### PR DESCRIPTION
# Add Discovery Topic
With the discovery topic hardcoded to `homeassistant`, those that don't use the default `homeassistant` prefix for the discovery topic are currently unable to utilize MQTT auto-discovery. This PR introduces a new `discovery_topic` key in the mqtt config (and DISCOVERY_TOPIC env variable for regular container users) which can be used to define the custom discovery topic that a user's HA is set to use.

`Note:` If a user doesn't define a `discovery_topic`, ps5-mqtt will by default use `homeassistant`. So, users updating will not have to worry about this being a breaking change and needing to define the `discovery_topic` - that will remain reserved for those with a custom discovery topic.

## Examples

**The examples below were carried out using a build containing the code changes seen in this PR**


### 1) If the `discovery_topic` is not set, ps5-mqtt will publish to the default `homeassistant` discovery topic

![ps5_default_discovery_topic](https://github.com/FunkeyFlo/ps5-mqtt/assets/52541649/b1b36094-b25f-4133-97fe-f9f9f3dc4a3d)

### 2) If the `discovery_topic` is set by the user (it was set to `RANDOM_DISCOVERY_TOPIC` in this example), ps5-mqtt will publish to this discovery topic instead of `homeassistant`
![ps5_custom_discovery_topic](https://github.com/FunkeyFlo/ps5-mqtt/assets/52541649/19591718-a75f-4b2c-8e0a-07b54b4ae3b5)

# Throw descriptive error if device state stdout is empty

Based on my testing, the JSON parsing error occurs when the Playstation is unreachable (resulting in `stdout` being empty) - 
this will happen once when sending the Playstation into rest mode and continue to happen if the user completely turned off their Playstation / it is no longer reachable on their network. In order to provide some insight, a descriptive error message has been added to let users know what is going on.

### 1) If the user sends their Playstation into rest mode, the system will fail to get any data from the Playstation once. This results in the error getting logged, but the message reassures them that it only matters if the error continues to flood the log. See below of an example where the PS5 was sent into rest mode, the error was logged (due to stdout being temporarily empty), and then info started flowing again.

```log
2024-06-14T01:02:51.311Z @ha:ps5:mqtt MQTT Message received ps5-mqtt/REDACTED/set/power
2024-06-14T01:02:56.320Z @ha:ps5:turnOffDevice 
2024-06-14T01:02:56.322Z @ha:ps5:mqtt MQTT Message received ps5-mqtt/REDACTED
2024-06-14T01:03:06.314Z @ha:ps5:checkDevicesState Resume polling
2024-06-14T01:03:06.848Z @ha:ps5:checkDevicesState {"address":{"address":"REDACTED","family":"IPv4","port":9302,"size":170},"hostRequestPort":997,"extras":{"statusLine":"620 Server Standby","statusCode":"620","statusMessage":"Server","status":"STANDBY"},"discoveryVersion":"00030010","systemVersion":"09400008","id":"REDACTED","name":"PS5-REDACTED","status":"STANDBY","type":"PS5"}

2024-06-14T01:03:12.424Z @ha:ps5:checkDevicesState {"address":{"address":"REDACTED","family":"IPv4","port":9302,"size":170},"hostRequestPort":997,"extras":{"statusLine":"620 Server Standby","statusCode":"620","statusMessage":"Server","status":"STANDBY"},"discoveryVersion":"00030010","systemVersion":"09400008","id":"REDACTED","name":"PS5-REDACTED","status":"STANDBY","type":"PS5"}

2024-06-14T01:03:32.450Z @ha:ps5:error No data received from Playstation. If this error continues, your Playstation is likely powered off or unreachable - it will not be available until it is in either rest mode/powered on and reachable.
2024-06-14T01:03:32.451Z @ha:ps5:mqtt MQTT Message received ps5-mqtt/REDACTED
2024-06-14T01:03:37.977Z @ha:ps5:checkDevicesState {"address":{"address":"REDACTED","family":"IPv4","port":9302,"size":170},"hostRequestPort":997,"extras":{"statusLine":"620 Server Standby","statusCode":"620","statusMessage":"Server","status":"STANDBY"},"discoveryVersion":"00030010","systemVersion":"09400008","id":"REDACTED","name":"PS5-REDACTED","status":"STANDBY","type":"PS5"}

2024-06-14T01:03:37.977Z @ha:ps5:checkDevicesState Update HA
2024-06-14T01:03:37.982Z @ha:ps5:mqtt MQTT Message received ps5-mqtt/REDACTED
2024-06-14T01:03:43.527Z @ha:ps5:checkDevicesState {"address":{"address":"REDACTED","family":"IPv4","port":9302,"size":170},"hostRequestPort":997,"extras":{"statusLine":"620 Server Standby","statusCode":"620","statusMessage":"Server","status":"STANDBY"},"discoveryVersion":"00030010","systemVersion":"09400008","id":"REDACTED","name":"PS5-REDACTED","status":"STANDBY","type":"PS5"}

2024-06-14T01:03:49.057Z @ha:ps5:checkDevicesState {"address":{"address":"REDACTED","family":"IPv4","port":9302,"size":170},"hostRequestPort":997,"extras":{"statusLine":"620 Server Standby","statusCode":"620","statusMessage":"Server","status":"STANDBY"},"discoveryVersion":"00030010","systemVersion":"09400008","id":"REDACTED","name":"PS5-REDACTED","status":"STANDBY","type":"PS5"}
```

### 2 If the Playstation is completely powered off or unreachable, `stdout` will always be empty, so, the descriptive error message will continue to get logged. See below:

```log
2024-06-14T01:09:12.554Z @ha:ps5:error No data received from Playstation. If this error continues, your Playstation is likely powered off or unreachable - it will not be available until it is in either rest mode/powered on and reachable.
2024-06-14T01:09:12.558Z @ha:ps5:mqtt MQTT Message received ps5-mqtt/REDACTED
2024-06-14T01:09:32.573Z @ha:ps5:error No data received from Playstation. If this error continues, your Playstation is likely powered off or unreachable - it will not be available until it is in either rest mode/powered on and reachable.
2024-06-14T01:09:32.574Z @ha:ps5:mqtt MQTT Message received ps5-mqtt/REDACTED
2024-06-14T01:09:52.597Z @ha:ps5:error No data received from Playstation. If this error continues, your Playstation is likely powered off or unreachable - it will not be available until it is in either rest mode/powered on and reachable.
2024-06-14T01:09:52.598Z @ha:ps5:mqtt MQTT Message received ps5-mqtt/REDACTED
2024-06-14T01:10:12.618Z @ha:ps5:error No data received from Playstation. If this error continues, your Playstation is likely powered off or unreachable - it will not be available until it is in either rest mode/powered on and reachable.
2024-06-14T01:10:12.619Z @ha:ps5:mqtt MQTT Message received ps5-mqtt/REDACTED
2024-06-14T01:10:32.634Z @ha:ps5:error No data received from Playstation. If this error continues, your Playstation is likely powered off or unreachable - it will not be available until it is in either rest mode/powered on and reachable.
2024-06-14T01:10:32.635Z @ha:ps5:mqtt MQTT Message received ps5-mqtt/REDACTED
2024-06-14T01:10:52.659Z @ha:ps5:error No data received from Playstation. If this error continues, your Playstation is likely powered off or unreachable - it will not be available until it is in either rest mode/powered on and reachable.
2024-06-14T01:10:52.661Z @ha:ps5:mqtt MQTT Message received ps5-mqtt/REDACTED
2024-06-14T01:11:12.670Z @ha:ps5:error No data received from Playstation. If this error continues, your Playstation is likely powered off or unreachable - it will not be available until it is in either rest mode/powered on and reachable.
2024-06-14T01:11:12.671Z @ha:ps5:mqtt MQTT Message received ps5-mqtt/REDACTED
2024-06-14T01:11:32.685Z @ha:ps5:error No data received from Playstation. If this error continues, your Playstation is likely powered off or unreachable - it will not be available until it is in either rest mode/powered on and reachable.
2024-06-14T01:11:32.686Z @ha:ps5:mqtt MQTT Message received ps5-mqtt/REDACTED
```

## Related Issues
- Closes #361 
- Closes #402 
- Closes #409 