### PR TITLE
Make my changes back

### DIFF
--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -63,6 +63,12 @@ services:
 
       - CREDENTIAL_STORAGE_PATH=/config/credentials.json
       - DEBUG=@ha:ps5:*
+    healthcheck:                                        # Optional add docker healthcheck as it may be important for some setups
+      test: ls -l /proc/*/exe | grep node
+      interval: 5m00s
+      timeout: 10s
+      retries: 2
+      start_period: 30s
 ```
 
 *NOTE: for more information on configuration variables please refer to the [add-on docs][add-on-docs] and the [regular startup script][regular-startup-script].*

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -41,7 +41,7 @@ services:
   ps5-mqtt:
     container_name: PS5-MQTT                            # choose whatever name you like
     image: ghcr.io/funkeyflo/ps5-mqtt/amd64:latest      # you can also use a specific version
-    entrypoint: node app/server/dist/index.js           # the file that will be executed at startup
+    entrypoint: /app/entrypoint.sh                      # the file that will be executed at startup
     volumes:                                            # we will use this volume to save credentials and get our custom startup script into the container
       - ./config:/config
     network_mode: host                                  # changing/omiting this option WILL BREAK the app.

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -42,7 +42,7 @@ services:
     container_name: PS5-MQTT                            # choose whatever name you like
     image: ghcr.io/funkeyflo/ps5-mqtt/amd64:latest      # you can also use a specific version
     entrypoint: /app/entrypoint.sh                      # the file that will be executed at startup
-    volumes:                                            # we will use this volume to save credentials and get our custom startup script into the container
+    volumes:                                            # we will use this volume to save credentials
       - ./config:/config
     network_mode: host                                  # changing/omiting this option WILL BREAK the app.
     environment:

--- a/ps5-mqtt/entrypoint.sh
+++ b/ps5-mqtt/entrypoint.sh
@@ -4,4 +4,6 @@ set -e
 echo Starting PS5-MQTT...
 node app/server/dist/index.js
 
+echo PS5-MQTT exited, shutdown now.
+
 exit 0

--- a/ps5-mqtt/entrypoint.sh
+++ b/ps5-mqtt/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+echo Starting PS5-MQTT...
+node app/server/dist/index.js
+
+exit 0


### PR DESCRIPTION
Hey, seems I outsmarted myself and caused #420. You right if it is executed without `set -e` it will produced a lot of Zombies. I didn't found a way to run it in one line, so I bring start script back with few changes:

1. Add script to the `/app` folder to reduce user effort
2. Add message on exit
3. Add `healthcheck`