### PR TITLE
updateAccount: fix the case when user is already in the players array

### DIFF
--- a/ps5-mqtt/server/src/redux/sagas/update-account.ts
+++ b/ps5-mqtt/server/src/redux/sagas/update-account.ts
@@ -25,16 +25,21 @@ function* updateAccount({ payload: account }: UpdateAccountAction) {
 
         bestMatch = devices.find(d => d.status === 'AWAKE' && d.type === account.activity.launchPlatform);
         if (bestMatch !== undefined) {
-            // if there already is an activity on that device add the player to the active player list
-            if (bestMatch.activity !== undefined && !bestMatch.activity.activePlayers.includes(account.accountName)) {
-                bestMatch.activity.activePlayers.push(account.accountName);
-            }
-            // otherwise add activity to matched device
-            else {
+            if (bestMatch.activity) {
+                if (!bestMatch.activity.activePlayers) {
+                    bestMatch.activity.activePlayers = [];
+                }
+
+                // Add the account to activePlayers if not already present
+                if (!bestMatch.activity.activePlayers.includes(account.accountName)) {
+                    bestMatch.activity.activePlayers.push(account.accountName);
+                }
+            } else {
+                // Create a new activity object if none exists
                 bestMatch.activity = {
                     ...account.activity,
                     activePlayers: [account.accountName]
-                }
+                };
             }
         }
     }


### PR DESCRIPTION
I have created sensors for `Player 1` and `Player 2`, where I am just reading from the array players.

However, I noticed that the `Player 2` was flickering.. changing from a `User` to `<none>` pretty regularly. I checked the mqtt and I saw 2 user, 1 user, 2 users, 1 user.. something was constantly removing 2nd user and adding it back.

![image](https://github.com/user-attachments/assets/91a7b57c-d05d-4622-9f87-8d2a3fd334de)


I check the code and saw a condition
```typescript
if (bestMatch.activity !== undefined && !bestMatch.activity.activePlayers.includes(account.accountName)) {
    bestMatch.activity.activePlayers.push(account.accountName);
}
// otherwise add activity to matched device
else {
bestMatch.activity = {
    ...account.activity,
    activePlayers: [account.accountName]
}
```

if we have user `user1` and the `activePlayers = ['user1', 'user2']` then the if is false -> activity is not undefined and the activePlayers contains the user1, so we got to the else and we override the `['user1', 'user2']` to `['user1']`
later comes update for user2 and it will be appended to the array. so this is why I saw the flickering.

