### PR TITLE
Change "Link" to "Pair"

### DIFF
--- a/ps5-mqtt/client/src/authenticate.tsx
+++ b/ps5-mqtt/client/src/authenticate.tsx
@@ -66,7 +66,7 @@ export const Authenticate: React.FC<{
                 </Grommet.FormField>
 
                 <Grommet.Paragraph margin="none">
-                    On your PlayStation 5, go to Settings &gt; System &gt; Remote Play &gt; Link Device.
+                    On your PlayStation 5, go to Settings &gt; System &gt; Remote Play &gt; Pair Device.
                     Enter the PIN Code below.
                 </Grommet.Paragraph>
 


### PR DESCRIPTION
Changed to the modern representation. Gotta say it got me confused a few times in the past.
The screenshot is from the latest PS5 software.
![19910ec905c97-screenshotUrl](https://github.com/user-attachments/assets/b7e99e72-c3b7-4e6e-90ae-43219aabb5d9)
