### PR TITLE
Fix PR autolabeler passing an invalid release-drafter input

### DIFF
--- a/.github/workflows/ensure-pr-release-label.yml
+++ b/.github/workflows/ensure-pr-release-label.yml
@@ -26,10 +26,9 @@ jobs:
       pull-requests: write
     steps:
       - name: 🏷 Apply autolabeler rules
-        uses: release-drafter/release-drafter@v7
+        uses: release-drafter/release-drafter/autolabeler@v7
         with:
           config-name: release-drafter.yml
-          disable-releaser: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- `ensure-pr-release-label.yml` called `release-drafter/release-drafter@v7` with a `disable-releaser: true` input, but that action has no such input (it's silently dropped with an `Unexpected input(s)` warning). The action then fell through to its default behavior of creating/updating a release, which 403'd on every PR since the job only grants `pull-requests: write`, not `contents: write` — so no PR ever got labeled.
- Switched the step to the dedicated `release-drafter/release-drafter/autolabeler@v7` sub-action, which only applies labels from `release-drafter.yml` and never touches releases (this is release-drafter's documented recipe for label-only usage).
- Verified with `actionlint` that the `disable-releaser` warning is gone and no other issues remain in this workflow.
- Note: this PR's own "PR release label" check will still fail, because `pull_request_target` always runs the workflow *definition* from the base branch (`main`), not the PR branch — that's a GitHub security measure so PRs can't alter what a `pull_request_target` workflow does. The fix only takes effect for PRs opened after this merges to `main`.

Also relevant to #646: `Edge` and `Draft Release` (`on: push: branches: [main]`) have never fired because the commit that introduced them (#640) was the same commit that added the files — GitHub doesn't trigger `push` workflows on the commit that first adds them, only on subsequent pushes. Merging this PR will be the first push to `main` since then, which will activate both.

Fixes #646

## Test plan
- [x] `actionlint .github/workflows/*.yml` — no findings for `ensure-pr-release-label.yml`
- [ ] After merge, open a new PR (e.g. rebase a dependabot PR) and confirm it gets auto-labeled and the required-label check passes
- [ ] After merge, confirm `Edge` and `Draft Release` runs appear for the merge commit on `main`