### PR TITLE
fix: PR autolabeler using an invalid release-drafter input

### DIFF
--- a/.github/workflows/ensure-pr-release-label.yml
+++ b/.github/workflows/ensure-pr-release-label.yml
@@ -26,10 +26,9 @@ jobs:
       pull-requests: write
     steps:
       - name: 🏷 Apply autolabeler rules
-        uses: release-drafter/release-drafter@v7
+        uses: release-drafter/release-drafter/autolabeler@v7
         with:
           config-name: release-drafter.yml
-          disable-releaser: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
release-drafter/release-drafter@v7 has no disable-releaser input (it's silently dropped with a warning), so the autolabel job fell through to its default release-creation path and 403'd on every PR since the job only grants pull-requests: write.

Switch to the dedicated release-drafter/release-drafter/autolabeler@v7 sub-action, which only applies labels and never touches releases.

Fixes #646