### PR TITLE
fix: removal of intermediate packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,11 +266,11 @@ jobs:
         # The per-arch and combined -build images only exist so imagetools can
         # stitch the multi-arch manifest; once promoted they're dead weight and
         # should never be visible to users. Cleanup failure must not fail the
-        # build (requires the repo to have admin on the packages, which
-        # GITHUB_TOKEN-published packages grant automatically).
+        # build. Package deletion is not supported by GITHUB_TOKEN, so this
+        # needs a classic PAT with read:packages + delete:packages scopes.
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DELETE_INTERMEDIATE_PACKAGES_TOKEN }}
         run: |
           set -euo pipefail
           pkgs=$(gh api "/users/${GITHUB_REPOSITORY_OWNER}/packages?package_type=container" \

--- a/.github/workflows/cleanup-pr-images.yml
+++ b/.github/workflows/cleanup-pr-images.yml
@@ -16,9 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🧹 Delete pr-${{ github.event.pull_request.number }} image tags
+        # Package/version deletion is not supported by GITHUB_TOKEN, so this
+        # needs a classic PAT with read:packages + delete:packages scopes.
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DELETE_INTERMEDIATE_PACKAGES_TOKEN }}
           TAG: pr-${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -268,11 +268,11 @@ jobs:
         # The per-arch and combined -build images only exist so imagetools can
         # stitch the multi-arch manifest; once promoted they're dead weight and
         # should never be visible to users. Cleanup failure must not fail the
-        # build (requires the repo to have admin on the packages, which
-        # GITHUB_TOKEN-published packages grant automatically).
+        # build. Package deletion is not supported by GITHUB_TOKEN, so this
+        # needs a classic PAT with read:packages + delete:packages scopes.
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DELETE_INTERMEDIATE_PACKAGES_TOKEN }}
         run: |
           set -euo pipefail
           pkgs=$(gh api "/users/${GITHUB_REPOSITORY_OWNER}/packages?package_type=container" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,11 +317,11 @@ jobs:
         # The per-arch and combined -build images only exist so imagetools can
         # stitch the multi-arch manifest; once promoted they're dead weight and
         # should never be visible to users. Cleanup failure must not fail the
-        # release (requires the repo to have admin on the packages, which
-        # GITHUB_TOKEN-published packages grant automatically).
+        # release. Package deletion is not supported by GITHUB_TOKEN, so this
+        # needs a classic PAT with read:packages + delete:packages scopes.
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DELETE_INTERMEDIATE_PACKAGES_TOKEN }}
         run: |
           set -euo pipefail
           pkgs=$(gh api "/users/${GITHUB_REPOSITORY_OWNER}/packages?package_type=container" \


### PR DESCRIPTION
Fix intermediate `-build` container images (and closed-PR image tags) never actually being deleted after publish.

Root cause: cleanup steps in `edge.yml`, `ci.yml`, `release.yml`, and `cleanup-pr-images.yml` called the GitHub Packages delete API using `secrets.GITHUB_TOKEN`. That token cannot perform package/version deletion — it requires a classic PAT with `read:packages` + `delete:packages` scopes; so every delete call was failing and being silently swallowed by `continue-on-error: true`.

Effect: users could see (and pull) internal intermediate images like `amd64-ps5-mqtt-home-assistant-add-on-edge-build`, `aarch64-ps5-mqtt-home-assistant-add-on-edge-build`, and `ps5-mqtt-home-assistant-add-on-edge-build`, which are only meant to exist transiently while `docker buildx imagetools` stitches the multi-arch manifest.
- Fix: swap `GH_TOKEN`/`GITHUB_TOKEN` for a new `secrets.DELETE_INTERMEDIATE_PACKAGES_TOKEN` (a classic PAT with the required scopes) in all four cleanup steps, and update the accompanying comments to reflect why a PAT is needed instead of `GITHUB_TOKEN`.

## Setup required (not part of this diff)

- [ ] Add a repo secret `DELETE_INTERMEDIATE_PACKAGES_TOKEN`: a classic PAT scoped to `read:packages` + `delete:packages`.
- [ ] One-time manual cleanup of the 3 packages already stuck from before this fix (the new token isn't retroactive).