### PR TITLE
chore: better logging around missing configuration

### DIFF
--- a/add-ons/common/run.sh
+++ b/add-ons/common/run.sh
@@ -8,11 +8,25 @@ if bashio::config.is_empty 'mqtt' && bashio::var.has_value "$(bashio::services '
     export MQTT_PORT="$(bashio::services 'mqtt' 'port')"
     export MQTT_USERNAME="$(bashio::services 'mqtt' 'username')"
     export MQTT_PASSWORD="$(bashio::services 'mqtt' 'password')"
-else 
+else
     export MQTT_HOST=$(bashio::config 'mqtt.host')
     export MQTT_PORT=$(bashio::config 'mqtt.port')
     export MQTT_USERNAME=$(bashio::config 'mqtt.user')
     export MQTT_PASSWORD=$(bashio::config 'mqtt.pass')
+fi
+
+# bashio returns the literal string "null" for unset optional config/service
+# values instead of an empty string; normalize that back to empty here so
+# downstream consumers (Node's mqtt client, etc.) don't treat it as a real value.
+[ "$MQTT_PORT" = "null" ] && export MQTT_PORT=""
+[ "$MQTT_USERNAME" = "null" ] && export MQTT_USERNAME=""
+[ "$MQTT_PASSWORD" = "null" ] && export MQTT_PASSWORD=""
+
+if [ -z "$MQTT_HOST" ] || [ "$MQTT_HOST" = "null" ]; then
+    bashio::log.fatal "No MQTT broker could be found or configured."
+    bashio::log.fatal "Install/configure an MQTT broker (e.g. the Mosquitto broker add-on) so it can be auto-discovered,"
+    bashio::log.fatal "or set the 'mqtt' options (host, port, user, pass) in this add-on's Configuration tab."
+    bashio::exit.nok
 fi
 
 export FRONTEND_PORT=8645
@@ -23,8 +37,9 @@ fi
 # configure logger
 export DEBUG="*,-mqttjs*,-mqtt-packet*,-playactor:*,-@ha:state*,-@ha:ps5:poll*,-@ha:ps5:check*"
 
-if [ ! -z $(bashio::config 'logger') ]; then
-    DEBUG=$(bashio::config 'logger')
+logger=$(bashio::config 'logger')
+if [ -n "$logger" ] && [ "$logger" != "null" ]; then
+    DEBUG="$logger"
 fi
 
 echo Starting PS5-MQTT...


### PR DESCRIPTION
Closes #652

## Summary
Fixes a crash on startup (`getaddrinfo ENOTFOUND null`) that occurs when no MQTT broker can be discovered or configured. bashio returns the literal string `"null"` for unset optional config/service values, and `run.sh` passed that straight through to the app as `MQTT_HOST`/`PORT`/`USERNAME`/`PASSWORD`, producing a cryptic Node crash instead of an actionable error.

- Normalize `"null"` MQTT_* values back to empty before use.
- Fail fast with a clear `bashio::log.fatal` message when no MQTT host is available, explaining how to fix it (configure an MQTT broker for auto-discovery, or set `mqtt` options manually).
- Fixed the same `"null"`-string bug in the `logger`/`DEBUG` fallback.