### PR TITLE
chore(ci): unify HA add-on image name, drop PR tags for it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ concurrency:
 
 env:
   ARCHITECTURES: '["amd64", "aarch64"]'
-  IMAGE_NAME: ps5-mqtt-home-assistant-add-on-edge
   BUILD_IMAGE_NAME: ps5-mqtt-home-assistant-add-on-edge-build
 
 jobs:
@@ -192,8 +191,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
-      id-token: write
-      packages: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
@@ -208,6 +205,10 @@ jobs:
           path: add-ons/ps5-mqtt-edge
 
       - name: 🏭 Build ${{ matrix.arch }} add-on - ${{ needs.init.outputs.tag }}
+        # The HA add-on is only ever pulled by the exact version pinned in its
+        # config.yaml (ps5-mqtt / ps5-mqtt-edge), so a pr-N tag would never be
+        # reachable from Home Assistant. Build it here to validate the image
+        # still builds for each arch, but never push it.
         uses: home-assistant/builder/actions/build-image@2026.06.0
         with:
           arch: ${{ matrix.arch }}
@@ -219,68 +220,8 @@ jobs:
           image-tags: |
             ${{ needs.init.outputs.tag }}
           version: ${{ needs.init.outputs.tag }}
-          push: ${{ needs.init.outputs.push }}
-          cosign: ${{ needs.init.outputs.push }}
-
-  manifest:
-    name: 📦 Publish multi-arch manifest - ${{ needs.init.outputs.tag }}
-    if: needs.init.outputs.push == 'true'
-    needs: [init, build]
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      packages: write
-    steps:
-      - name: 📦 Publish multi-arch manifest
-        uses: home-assistant/builder/actions/publish-multi-arch-manifest@2026.06.0
-        with:
-          architectures: ${{ env.ARCHITECTURES }}
-          container-registry-password: ${{ secrets.GITHUB_TOKEN }}
-          image-name: ${{ env.BUILD_IMAGE_NAME }}
-          registry-prefix: ${{ needs.init.outputs.registry-prefix }}
-          image-tags: |
-            ${{ needs.init.outputs.tag }}
-
-      - name: 🏷️ Promote multi-arch manifest
-        run: |
-          # GHCR namespaces must be lowercase; github.repository_owner may not be.
-          REGISTRY_PREFIX="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}"
-          tags=("${{ needs.init.outputs.tag }}")
-
-          tag_args=()
-          for tag in "${tags[@]}"; do
-            tag_args+=("--tag" "${REGISTRY_PREFIX}/${IMAGE_NAME}:${tag}")
-          done
-
-          metadata_file="$(mktemp)"
-
-          docker buildx imagetools create \
-            --metadata-file "${metadata_file}" \
-            "${tag_args[@]}" \
-            "${REGISTRY_PREFIX}/${BUILD_IMAGE_NAME}:${tags[0]}"
-
-          digest="$(jq -r '.["containerimage.descriptor"].digest' "${metadata_file}")"
-          cosign sign --yes "${REGISTRY_PREFIX}/${IMAGE_NAME}@${digest}"
-
-      - name: 🧹 Delete intermediate -build packages
-        # The per-arch and combined -build images only exist so imagetools can
-        # stitch the multi-arch manifest; once promoted they're dead weight and
-        # should never be visible to users. Cleanup failure must not fail the
-        # build. Package deletion is not supported by GITHUB_TOKEN, so this
-        # needs a classic PAT with read:packages + delete:packages scopes.
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.DELETE_INTERMEDIATE_PACKAGES_TOKEN }}
-        run: |
-          set -euo pipefail
-          pkgs=$(gh api "/users/${GITHUB_REPOSITORY_OWNER}/packages?package_type=container" \
-            --paginate --jq '.[].name' | grep -F "${BUILD_IMAGE_NAME}" || true)
-          [ -z "$pkgs" ] && { echo "No -build packages found"; exit 0; }
-          while IFS= read -r pkg; do
-            enc=$(jq -rn --arg p "$pkg" '$p|@uri')
-            echo "Deleting intermediate package ${pkg}"
-            gh api -X DELETE "/users/${GITHUB_REPOSITORY_OWNER}/packages/container/${enc}"
-          done <<< "$pkgs"
+          push: "false"
+          cosign: "false"
 
   standalone:
     name: 🐳 Build standalone image - ${{ needs.init.outputs.tag }}

--- a/.github/workflows/cleanup-pr-images.yml
+++ b/.github/workflows/cleanup-pr-images.yml
@@ -25,14 +25,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Consumer packages that CI pushes PR tags to, plus any -build
-          # intermediates a failed run may have left behind.
-          packages="ps5-mqtt ps5-mqtt-home-assistant-add-on-edge"
-          leftovers=$(gh api "/users/${GITHUB_REPOSITORY_OWNER}/packages?package_type=container" \
-            --paginate --jq '.[].name' \
-            | grep -F "ps5-mqtt-home-assistant-add-on-edge-build" || true)
+          # ps5-mqtt is the only consumer package CI pushes PR tags to; the HA
+          # add-on is only ever pulled by the version pinned in its
+          # config.yaml, so CI never pushes a pr-N tag for it.
+          packages="ps5-mqtt"
 
-          for pkg in $packages $leftovers; do
+          for pkg in $packages; do
             enc=$(jq -rn --arg p "$pkg" '$p|@uri')
             ids=$(gh api "/users/${GITHUB_REPOSITORY_OWNER}/packages/container/${enc}/versions" \
               --paginate \

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   ARCHITECTURES: '["amd64", "aarch64"]'
-  IMAGE_NAME: ps5-mqtt-home-assistant-add-on-edge
+  IMAGE_NAME: ps5-mqtt-home-assistant-add-on
   BUILD_IMAGE_NAME: ps5-mqtt-home-assistant-add-on-edge-build
 
 jobs:

--- a/add-ons/ps5-mqtt-edge/config.yaml
+++ b/add-ons/ps5-mqtt-edge/config.yaml
@@ -47,4 +47,4 @@ schema:
   account_check_interval: int
   include_ps4_devices: bool
 stdin: true
-image: "ghcr.io/funkeyflo/ps5-mqtt-home-assistant-add-on-edge"
+image: "ghcr.io/funkeyflo/ps5-mqtt-home-assistant-add-on"


### PR DESCRIPTION
Relates to #652 

## Summary
- The Home Assistant add-on image was published under a separate `ps5-mqtt-home-assistant-add-on-edge` repo for edge/PR builds, while releases published to `ps5-mqtt-home-assistant-add-on`. Edge/main builds (`edge.yml`) now publish to the same repo as releases, tagged `edge` and `<sha>` — mirroring how the standalone `ps5-mqtt` image differentiates by tag rather than by repo name.
- `add-ons/ps5-mqtt-edge/config.yaml` now points its `image:` at `ghcr.io/funkeyflo/ps5-mqtt-home-assistant-add-on` (version stays `"edge"`, so the installable dev add-on still resolves to the `:edge` tag).
- CI (`ci.yml`) still builds the add-on per-arch on every PR to catch build breaks, but no longer pushes a `pr-N` tag for it: HA add-ons are only ever pulled at the exact version pinned in `config.yaml`, so a floating `pr-N` tag on that image was never reachable/consumable. The multi-arch manifest/promote job for PR builds was removed accordingly.
- `cleanup-pr-images.yml` no longer references the HA add-on package, since nothing is published there for PRs anymore. The standalone `ps5-mqtt:pr-N` image is unaffected by any of this.

## Test plan

> Note the test plan cannot be fully completed until merged to main.

- [x] CI run on this PR builds the add-on for both archs without pushing, and still publishes `ps5-mqtt:pr-<this PR#>`
- [ ] Next push to `main` publishes `ghcr.io/funkeyflo/ps5-mqtt-home-assistant-add-on:edge`
- [ ] Next tagged release still publishes `ghcr.io/funkeyflo/ps5-mqtt-home-assistant-add-on:<version>` and `:latest` as before