### PR TITLE
feat: add optional login_passcode for passcode-protected profiles

### DIFF
--- a/add-ons/ps5-mqtt-edge/config.yaml
+++ b/add-ons/ps5-mqtt-edge/config.yaml
@@ -46,5 +46,6 @@ schema:
   device_discovery_interval: int
   account_check_interval: int
   include_ps4_devices: bool
+  login_passcode: str?
 stdin: true
 image: "ghcr.io/funkeyflo/ps5-mqtt-home-assistant-add-on"

--- a/add-ons/ps5-mqtt/DOCS.md
+++ b/add-ons/ps5-mqtt/DOCS.md
@@ -13,6 +13,8 @@ device_discovery_interval: 60000    # Recommended interval for discovering 'new'
 
 include_ps4_devices: false          # Only enable if you only require awake/standby functionality
 
+login_passcode: '!secret my_ps5_passcode'  # [optional] Profile login passcode; required if the console profile is passcode-protected
+
 psn_accounts:                       # [optional] Add PSN accounts to match online activity to your devices
   - username: MyPsnUser
     npsso: '!secret my_npsso'       # NPSSO token (expires after two months 😢)
@@ -90,6 +92,24 @@ IP address the addon will use for UDP broadcasting which is required for device 
 If your devices are located on a VLAN you must use this option to point the addon to the broadcast ip of the VLAN your devices are located on.
 
 _NOTE: only one broadcast address is supported. So all devices will need to be on the same VLAN._
+
+### `login_passcode` _optional_
+
+The login passcode of the PlayStation user profile used for the pairing/registration.
+
+Set this **only if that profile is protected by a login passcode**. When the profile is passcode-protected, `standby`/`wake` will otherwise fail with `PASSCODE_IS_NEEDED` (often intermittently, depending on the console's state), and the device will not turn on/off. Providing the passcode here forwards it to `playactor` so the commands succeed.
+
+The value is either the numeric passcode (e.g. `2292`) or a space-separated string of controller key names (e.g. `up up down down`), matching `playactor`'s `--pass-code` option.
+
+```yaml
+login_passcode: "!secret my_ps5_passcode"
+```
+
+_NOTE 1: A single passcode is applied to all managed devices. Multiple consoles with different profile passcodes are not yet supported._
+
+_NOTE 2: This is a credential — use a `!secret` as shown._
+
+_NOTE 3: Alternatively, disable the passcode requirement on the console (Settings → Users and Accounts → Login Settings) and leave this unset._
 
 <!-- LINKS -->
 

--- a/add-ons/ps5-mqtt/config.yaml
+++ b/add-ons/ps5-mqtt/config.yaml
@@ -46,5 +46,6 @@ schema:
   device_discovery_interval: int
   account_check_interval: int
   include_ps4_devices: bool
+  login_passcode: str?
 stdin: true
 image: ghcr.io/funkeyflo/ps5-mqtt-home-assistant-add-on

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -66,6 +66,8 @@ services:
 
       - INCLUDE_PS4_DEVICES=false
 
+      - LOGIN_PASSCODE=2292 # [optional] profile login passcode; only needed if the console profile is passcode-protected (else standby/wake fail with PASSCODE_IS_NEEDED)
+
       - FRONTEND_PORT=8645
 
       - CREDENTIAL_STORAGE_PATH=/config/credentials.json

--- a/ps5-mqtt/server/src/app.ts
+++ b/ps5-mqtt/server/src/app.ts
@@ -85,6 +85,8 @@ export async function run() {
       path.join(os.homedir(), ".config", "playactor", "credentials.json"),
     allowPs4Devices: appConfig.include_ps4_devices ?? true,
 
+    loginPasscode: appConfig.login_passcode,
+
     deviceDiscoveryBroadcastAddress:
       appConfig.device_discovery_broadcast_address,
 

--- a/ps5-mqtt/server/src/config.ts
+++ b/ps5-mqtt/server/src/config.ts
@@ -18,6 +18,10 @@ export interface AppConfig {
   include_ps4_devices: boolean
   device_discovery_broadcast_address: string
 
+  // Optional PS5 profile login passcode (numeric passcode or a space-separated
+  // string of key names) forwarded to playactor for standby/wake.
+  login_passcode?: string
+
   psn_accounts: AppConfig.PsnAccountInfo[]
 
   account_check_interval: number
@@ -89,6 +93,8 @@ function getEnvConfig(): Partial<AppConfig> {
 
     CREDENTIAL_STORAGE_PATH,
 
+    LOGIN_PASSCODE,
+
     INCLUDE_PS4_DEVICES,
 
     DEVICE_DISCOVERY_BROADCAST_ADDRESS,
@@ -125,6 +131,8 @@ function getEnvConfig(): Partial<AppConfig> {
       : undefined,
 
     device_discovery_broadcast_address: DEVICE_DISCOVERY_BROADCAST_ADDRESS,
+
+    login_passcode: LOGIN_PASSCODE,
 
     credentialsStoragePath: CREDENTIAL_STORAGE_PATH,
     frontendPort: FRONTEND_PORT,

--- a/ps5-mqtt/server/src/redux/sagas/turn-off-device.ts
+++ b/ps5-mqtt/server/src/redux/sagas/turn-off-device.ts
@@ -4,6 +4,7 @@ import { getContext, put } from "redux-saga/effects"
 import sh from "shelljs"
 import { Settings, SETTINGS } from "../../services"
 import { createErrorLogger } from "../../util/error-logger"
+import { buildPassCodeArg } from "../../util/pass-code"
 import { setTransitioning, updateHomeAssistant } from "../action-creators"
 import type { ChangePowerModeAction } from "../types"
 
@@ -11,7 +12,8 @@ const debug = createDebugger("@ha:ps5:turnOffDevice")
 const debugError = createErrorLogger()
 
 function* turnOffDevice(action: ChangePowerModeAction) {
-  const { credentialStoragePath }: Settings = yield getContext(SETTINGS)
+  const { credentialStoragePath, loginPasscode }: Settings =
+    yield getContext(SETTINGS)
 
   if (action.payload.mode !== "STANDBY") {
     return
@@ -26,6 +28,7 @@ function* turnOffDevice(action: ChangePowerModeAction) {
     const { stdout, stderr } = sh.exec(
       `playactor standby --ip ${action.payload.device.address.address}` +
         ` --timeout 5000 --connect-timeout 5000 --no-open-urls --no-auth` +
+        buildPassCodeArg(loginPasscode) +
         ` -c ${credentialStoragePath}`,
       { silent: true, timeout: 5000 },
     )

--- a/ps5-mqtt/server/src/redux/sagas/turn-on-device.ts
+++ b/ps5-mqtt/server/src/redux/sagas/turn-on-device.ts
@@ -4,6 +4,7 @@ import { getContext, put } from "redux-saga/effects"
 import sh from "shelljs"
 import { Settings, SETTINGS } from "../../services"
 import { createErrorLogger } from "../../util/error-logger"
+import { buildPassCodeArg } from "../../util/pass-code"
 import { setTransitioning, updateHomeAssistant } from "../action-creators"
 import type { ChangePowerModeAction } from "../types"
 
@@ -11,7 +12,8 @@ const debug = createDebugger("@ha:ps5:turnOnDevice")
 const debugError = createErrorLogger()
 
 function* turnOnDevice(action: ChangePowerModeAction) {
-  const { credentialStoragePath }: Settings = yield getContext(SETTINGS)
+  const { credentialStoragePath, loginPasscode }: Settings =
+    yield getContext(SETTINGS)
 
   if (action.payload.mode !== "AWAKE") {
     return
@@ -26,6 +28,7 @@ function* turnOnDevice(action: ChangePowerModeAction) {
     const { stdout, stderr } = sh.exec(
       `playactor wake --ip ${action.payload.device.address.address}` +
         ` --timeout 5000 --connect-timeout 5000 --no-open-urls --no-auth` +
+        buildPassCodeArg(loginPasscode) +
         ` -c ${credentialStoragePath}`,
       { silent: true, timeout: 5000 },
     )

--- a/ps5-mqtt/server/src/services.ts
+++ b/ps5-mqtt/server/src/services.ts
@@ -10,6 +10,11 @@ export interface Settings {
   credentialStoragePath: string
   allowPs4Devices: boolean
 
+  // Optional PS5 login passcode, forwarded to playactor as `--pass-code` so
+  // standby/wake still work when the console profile is passcode-protected
+  // (otherwise playactor fails with PASSCODE_IS_NEEDED).
+  loginPasscode?: string
+
   deviceDiscoveryBroadcastAddress: string
 
   discoveryTopic: string

--- a/ps5-mqtt/server/src/util/__tests__/pass-code.test.ts
+++ b/ps5-mqtt/server/src/util/__tests__/pass-code.test.ts
@@ -1,0 +1,29 @@
+import { buildPassCodeArg } from "../pass-code"
+
+describe("buildPassCodeArg", () => {
+  test("returns an empty string when no passcode is provided", () => {
+    expect(buildPassCodeArg(undefined)).toBe("")
+    expect(buildPassCodeArg("")).toBe("")
+    expect(buildPassCodeArg("   ")).toBe("")
+  })
+
+  test("builds a quoted --pass-code fragment for a numeric passcode", () => {
+    expect(buildPassCodeArg("2292")).toBe(" --pass-code '2292'")
+  })
+
+  test("trims surrounding whitespace", () => {
+    expect(buildPassCodeArg("  2292 ")).toBe(" --pass-code '2292'")
+  })
+
+  test("supports a space-separated string of key names", () => {
+    expect(buildPassCodeArg("up up down down")).toBe(
+      " --pass-code 'up up down down'",
+    )
+  })
+
+  test("rejects values with shell metacharacters (injection guard)", () => {
+    expect(() => buildPassCodeArg("2292; rm -rf /")).toThrow()
+    expect(() => buildPassCodeArg("$(whoami)")).toThrow()
+    expect(() => buildPassCodeArg("2292'")).toThrow()
+  })
+})

--- a/ps5-mqtt/server/src/util/pass-code.ts
+++ b/ps5-mqtt/server/src/util/pass-code.ts
@@ -1,0 +1,26 @@
+/**
+ * Build the playactor `--pass-code` argument fragment for a power command.
+ *
+ * playactor requires the console profile's login passcode when the profile is
+ * passcode-protected; without it, standby/wake fail with `PASSCODE_IS_NEEDED`.
+ * The value is either a numeric passcode or a space-separated string of key
+ * names (e.g. "up up down down"), per playactor's `--pass-code` option.
+ *
+ * Returns an empty string when no passcode is configured. The value is
+ * validated against a strict character set and single-quoted so it is safe to
+ * embed in the shell command built by the turn-on/turn-off sagas.
+ *
+ * @throws if a non-empty passcode contains characters outside `[A-Za-z0-9 ]`.
+ */
+export function buildPassCodeArg(loginPasscode?: string): string {
+  const value = loginPasscode?.trim()
+  if (!value) {
+    return ""
+  }
+  if (!/^[A-Za-z0-9 ]+$/.test(value)) {
+    throw new Error(
+      "login_passcode must be a numeric passcode or a space-separated string of key names",
+    )
+  }
+  return ` --pass-code '${value}'`
+}


### PR DESCRIPTION
## Problem

`standby`/`wake` shell out to the `playactor` CLI. When the PlayStation user profile used for pairing is **passcode-protected**, playactor's remote-play login requires that passcode and otherwise fails with `PASSCODE_IS_NEEDED` (`remoteplay/proc/login.js`). In practice this is **intermittent** — it depends on the console's state at the moment of the command — so power control "usually works" but randomly leaves the console awake/asleep. There is currently no way to supply the profile login passcode, so passcode-protected profiles can't be reliably controlled.

## Change

Add an optional `login_passcode` option, forwarded to playactor's `--pass-code` on the `standby` and `wake` commands.

- **Add-on:** new `login_passcode: str?` in both `ps5-mqtt` and `ps5-mqtt-edge` `config.yaml` schemas (reaches the server via the existing `CONFIG_PATH`/`options.json`).
- **Docker:** new `LOGIN_PASSCODE` env var (parsed in `config.ts`).
- Plumbed through `AppConfig` → `Settings` → the turn-on/turn-off sagas.
- A small `buildPassCodeArg()` helper builds the ` --pass-code '<value>'` fragment. It accepts playactor's documented formats (a numeric passcode, or a space-separated string of key names), validates against `^[A-Za-z0-9 ]+$`, and single-quotes the value — so a malformed/hostile value can't inject into the shell command. **Unset ⇒ no change in behavior.**
- Unit tests for the helper (incl. injection guards); docs updated (`DOCS.md`, `DOCKER.md`).

## Notes / scope

- A single passcode applies to all managed devices. Multiple consoles with **different** profile passcodes aren't covered (documented). Happy to extend to per-device if you'd prefer that shape.
- Alternative for users: disabling the profile passcode on the console avoids the error entirely; this option is for those who want to keep it.

## Testing

- `buildPassCodeArg` unit tests added; verified the parsing/validation/injection-guard behavior, and the helper typechecks clean under `--strict`.
- Existing `config.test.ts` stays green (`login_passcode` is `undefined` when unset, which `lodash.merge` skips).
- Disclosure: I couldn't run the full yarn workspace build in my environment; please let CI exercise `typecheck` + the suite. Happy to adjust naming (e.g. `login_passcode` vs per-account) or approach.
