### PR TITLE
Fix power off (standby) reliability by detecting playactor timeout-kills

### DIFF
--- a/ps5-mqtt/server/src/app.ts
+++ b/ps5-mqtt/server/src/app.ts
@@ -110,6 +110,7 @@ export async function run() {
   const playactorClient = createPlayactorClient({
     credentialStoragePath: settings.credentialStoragePath,
     loginPasscode: settings.loginPasscode,
+    allowPs4Devices: settings.allowPs4Devices,
   })
 
   try {

--- a/ps5-mqtt/server/src/playactor/__tests__/client.test.ts
+++ b/ps5-mqtt/server/src/playactor/__tests__/client.test.ts
@@ -20,7 +20,7 @@ const WAKE_CMD =
 
 const STANDBY_CMD =
   `playactor standby --ip ${IP}` +
-  ` --timeout 5000 --connect-timeout 5000 --no-open-urls --no-auth` +
+  ` --timeout 10000 --connect-timeout 10000 --no-open-urls --no-auth` +
   ` -c ${CREDENTIAL_PATH}`
 
 const CHECK_CMD =
@@ -71,6 +71,30 @@ describe("PlayactorClient", () => {
 
       await expect(client.wake(IP)).rejects.toBe("boom")
     })
+
+    test("passes --ps5 when PS4 devices are excluded", async () => {
+      mockExec.mockReturnValue(execResult({ code: 0, stdout: "ok" }))
+      const ps5OnlyClient = createPlayactorClient({
+        credentialStoragePath: CREDENTIAL_PATH,
+        allowPs4Devices: false,
+      })
+
+      await ps5OnlyClient.wake(IP)
+
+      expect(mockExec).toHaveBeenCalledWith(
+        `playactor wake --ip ${IP}` +
+          ` --timeout 5000 --connect-timeout 5000 --no-open-urls --no-auth` +
+          ` --ps5 -c ${CREDENTIAL_PATH}`,
+        { silent: true, timeout: 5000 },
+      )
+    })
+
+    // https://github.com/FunkeyFlo/ps5-mqtt/issues/675
+    test("rejects when killed by the shelljs timeout (no stderr, non-zero exit code)", async () => {
+      mockExec.mockReturnValue(execResult({ code: 1, stdout: "", stderr: "" }))
+
+      await expect(client.wake(IP)).rejects.toThrow(/exited with code 1/)
+    })
   })
 
   describe("standby", () => {
@@ -80,7 +104,7 @@ describe("PlayactorClient", () => {
       await expect(client.standby(IP)).resolves.toBeUndefined()
       expect(mockExec).toHaveBeenCalledWith(STANDBY_CMD, {
         silent: true,
-        timeout: 5000,
+        timeout: 25000,
       })
     })
 
@@ -88,6 +112,39 @@ describe("PlayactorClient", () => {
       mockExec.mockReturnValue(execResult({ code: 0, stderr: "nope" }))
 
       await expect(client.standby(IP)).rejects.toBe("nope")
+    })
+
+    test("passes --ps5 when PS4 devices are excluded", async () => {
+      mockExec.mockReturnValue(execResult({ code: 0, stdout: "ok" }))
+      const ps5OnlyClient = createPlayactorClient({
+        credentialStoragePath: CREDENTIAL_PATH,
+        allowPs4Devices: false,
+      })
+
+      await ps5OnlyClient.standby(IP)
+
+      expect(mockExec).toHaveBeenCalledWith(
+        `playactor standby --ip ${IP}` +
+          ` --timeout 10000 --connect-timeout 10000 --no-open-urls --no-auth` +
+          ` --ps5 -c ${CREDENTIAL_PATH}`,
+        { silent: true, timeout: 25000 },
+      )
+    })
+
+    // https://github.com/FunkeyFlo/ps5-mqtt/issues/675
+    // Standby's full handshake (discovery, session init, login, passcode,
+    // then the standby request) can outlast a short shelljs timeout. When
+    // shelljs kills the process, it exits with code 1 and empty
+    // stdout/stderr - nothing throws, so the old stderr-only check never
+    // fired and the saga optimistically reported STANDBY even though the
+    // console never actually went to standby. Verified this is really how
+    // shelljs behaves on a timeout-kill (sh.exec("sleep N", { timeout:
+    // shortMs }) consistently returns { code: 1, stdout: "", stderr: "" });
+    // it could not be reproduced against real PS5 hardware.
+    test("rejects when killed by the shelljs timeout (no stderr, non-zero exit code)", async () => {
+      mockExec.mockReturnValue(execResult({ code: 1, stdout: "", stderr: "" }))
+
+      await expect(client.standby(IP)).rejects.toThrow(/exited with code 1/)
     })
   })
 

--- a/ps5-mqtt/server/src/playactor/client.ts
+++ b/ps5-mqtt/server/src/playactor/client.ts
@@ -9,7 +9,19 @@ const debug = createDebugger("@ha:ps5:playactor")
 export interface PlayactorClientSettings {
   credentialStoragePath: string
   loginPasscode?: string
+  allowPs4Devices?: boolean
 }
+
+// Standby requires a full Remote Play handshake (discovery, session init,
+// login, passcode, then the standby request itself), which can take much
+// longer than a simple wake. The shelljs timeout must safely exceed the sum
+// of the discovery/connect timeouts below so a slow but healthy handshake
+// isn't killed mid-flight. https://github.com/FunkeyFlo/ps5-mqtt/issues/675
+const STANDBY_DISCOVERY_TIMEOUT_MS = 10000
+const STANDBY_CONNECT_TIMEOUT_MS = 10000
+const STANDBY_SHELLJS_TIMEOUT_MS = 25000
+
+const WAKE_SHELLJS_TIMEOUT_MS = 5000
 
 /**
  * Thin wrapper around the `playactor` CLI. Centralizes the command building,
@@ -27,17 +39,25 @@ export interface PlayactorClient {
 export function createPlayactorClient({
   credentialStoragePath,
   loginPasscode,
+  allowPs4Devices,
 }: PlayactorClientSettings): PlayactorClient {
+  // Ignore non-PS5 devices during discovery when PS4 devices are excluded,
+  // shaving discovery latency off the timeout budget below.
+  const devicePs5Arg = allowPs4Devices === false ? " --ps5" : ""
+
   const buildWakeCommand = (ip: string): string =>
     `playactor wake --ip ${ip}` +
     ` --timeout 5000 --connect-timeout 5000 --no-open-urls --no-auth` +
     buildPassCodeArg(loginPasscode) +
+    devicePs5Arg +
     ` -c ${credentialStoragePath}`
 
   const buildStandbyCommand = (ip: string): string =>
     `playactor standby --ip ${ip}` +
-    ` --timeout 5000 --connect-timeout 5000 --no-open-urls --no-auth` +
+    ` --timeout ${STANDBY_DISCOVERY_TIMEOUT_MS}` +
+    ` --connect-timeout ${STANDBY_CONNECT_TIMEOUT_MS} --no-open-urls --no-auth` +
     buildPassCodeArg(loginPasscode) +
+    devicePs5Arg +
     ` -c ${credentialStoragePath}`
 
   const buildCheckCommand = (ip: string): string =>
@@ -45,23 +65,46 @@ export function createPlayactorClient({
     ` --timeout 15000 --connect-timeout 10000 --no-open-urls --no-auth` +
     ` -c ${credentialStoragePath}`
 
-  // wake/standby share identical exec + error handling; only the sub-command differs.
-  const runPowerCommand = async (command: string): Promise<void> => {
-    const { stdout, stderr } = sh.exec(command, { silent: true, timeout: 5000 })
+  // wake/standby share identical exec + error handling; only the sub-command
+  // and shelljs timeout differ.
+  const runPowerCommand = async (
+    command: string,
+    shelljsTimeoutMillis: number,
+  ): Promise<void> => {
+    const { code, stdout, stderr } = sh.exec(command, {
+      silent: true,
+      timeout: shelljsTimeoutMillis,
+    })
 
     if (stderr) {
       throw stderr
     }
+
+    // A shelljs timeout-kill produces no stderr, so `code` is the only
+    // remaining signal that the command didn't actually complete - without
+    // this check, a standby/wake killed mid-handshake looks identical to a
+    // successful one and gets optimistically reported to Home Assistant.
+    // https://github.com/FunkeyFlo/ps5-mqtt/issues/675
+    if (code !== 0) {
+      throw new Error(
+        `playactor exited with code ${code} without completing (it may ` +
+          "have been killed after exceeding the timeout)",
+      )
+    }
+
     debug(stdout)
   }
 
   return {
     async wake(ip: string): Promise<void> {
-      await runPowerCommand(buildWakeCommand(ip))
+      await runPowerCommand(buildWakeCommand(ip), WAKE_SHELLJS_TIMEOUT_MS)
     },
 
     async standby(ip: string): Promise<void> {
-      await runPowerCommand(buildStandbyCommand(ip))
+      await runPowerCommand(
+        buildStandbyCommand(ip),
+        STANDBY_SHELLJS_TIMEOUT_MS,
+      )
     },
 
     async check(ip: string): Promise<Device> {


### PR DESCRIPTION
Fixes #675

## The bug

`PlayactorClient.runPowerCommand` (shared by `wake()` and `standby()`) invokes the `playactor` CLI via `sh.exec(command, { silent: true, timeout: 5000 })` and only checks `if (stderr) throw stderr` to detect failure.

Standby requires a full Remote Play handshake (discovery, session init/ctrl, login, passcode, then the actual standby command), which can exceed the shared 5s timeout that's plenty for a fire-and-forget wake. When it does, shelljs kills the process before standby completes. The kill produces **no stderr**, so the `if (stderr) throw stderr` guard never fires, and the saga optimistically reports STANDBY to Home Assistant even though the console never actually went to standby.

Credit to the original issue reporter's diagnostic writeup for identifying this shape of the bug and proposing the fix directions below.

## What I verified vs. took on faith

- **Independently verified** (not just trusted from the issue): shelljs' actual timeout-kill behavior, since I don't have PS5 hardware to reproduce this end-to-end. Ran `sh.exec("sleep N", { silent: true, timeout: shortMs })` locally and confirmed it consistently returns `{ code: 1, stdout: "", stderr: "" }` - no thrown error, no stderr. This confirms the load-bearing claim the whole fix depends on: a timeout-kill is otherwise indistinguishable from success under the old check.
- **Independently verified**: `check()` in the same file already uses `code > 1 && stderr` rather than trusting stderr alone - but that exact check doesn't transfer to `wake`/`standby`. `check`'s exit codes 0/1 are two legitimate *successful* outcomes (Awake/Standby) per playactor's own documented convention (see `ExitCode.DeviceStandby = 1` in playactor's CLI source), whereas `wake`/`standby` have no such convention - they exit 0 on success and non-zero on any failure. So the correct check here is `code !== 0`, not `code > 1`.
- **Independently verified**: the pinned `playactor@0.4.1`'s CLI genuinely supports a `--ps5` flag (`DeviceOptions.deviceOnlyPS5` in its own `options.js`), confirmed by reading the installed package's source rather than assuming the flag exists.
- **Not verifiable without hardware**: whether the new, longer timeouts are exactly right for every network/console combination. I picked values with margin above the documented handshake steps; see reasoning below.

## The fix

In `server/src/playactor/client.ts`:

1. Raised `standby`'s playactor `--timeout`/`--connect-timeout` from 5000ms to 10000ms each, and its shelljs process timeout from 5000ms to 25000ms - comfortably covering discovery + connect + margin for login/passcode/the standby request itself, which have no timeout flag of their own. `wake`'s timeouts are unchanged (5000ms) since it has no equivalent handshake latency - it's a fire-and-forget UDP wake packet, per the issue's own evidence for why wake "just works" while standby doesn't.
2. `runPowerCommand` now falls back to checking the exit code when stderr is empty: `if (code !== 0) throw ...`. This catches the timeout-kill case (code 1, no stderr) that the old stderr-only check missed, without changing behavior for the existing stderr-present failure path (still thrown as-is, preserving existing callers/tests that assert on the raw stderr value).
3. Added the `--ps5` flag to `wake`/`standby` commands when `allowPs4Devices` is `false` (mirrors the existing `include_ps4_devices` → `allowPs4Devices` config flow already used by `discover-devices.ts`), trimming discovery latency within the new timeout budget. Threaded `allowPs4Devices` through `PlayactorClientSettings` and `app.ts`'s `createPlayactorClient(...)` call to make this available.

I scoped this fix to `standby`'s timeouts only (not `wake`'s) since the reported symptom and the handshake-latency root cause are specific to standby. The exit-code fallback check applies to both `wake` and `standby` since they share `runPowerCommand` and both have the identical latent gap - `wake` just doesn't usually hit it in practice, per the issue.

## Tests

Added to `server/src/playactor/__tests__/client.test.ts`:
- A regression test for `wake` and for `standby`: a timeout-kill-shaped result (`{ code: 1, stdout: "", stderr: "" }`) is rejected, rather than silently resolving.
- Tests for the new `--ps5` flag on both commands.
- Updated the existing `standby` "builds the correct command" test for the new timeout values.

`yarn test/unit`, `yarn typecheck`, `yarn lint`, and `yarn format/check` all pass locally, with 100% statement/branch coverage on the touched file.