### PR TITLE
fix: standby silently failing on Node >= 22.23 (free-socket data guard)

### DIFF
--- a/ps5-mqtt/server/rspack.config.mts
+++ b/ps5-mqtt/server/rspack.config.mts
@@ -1,12 +1,18 @@
 import { defineConfig } from "@rspack/cli"
 
 export default defineConfig({
-  entry: "./src/index.ts",
+  entry: {
+    index: "./src/index.ts",
+    // Tiny shim preloaded into every `playactor` child process, see
+    // src/playactor/preload.ts. Emitted as dist/playactor-preload.js next to
+    // index.js so src/playactor/client.ts can locate it via __dirname.
+    "playactor-preload": "./src/playactor/preload.ts",
+  },
   target: "node",
   devtool: "source-map",
   output: {
     path: __dirname + "/dist",
-    filename: "index.js",
+    filename: "[name].js",
     library: { type: "commonjs2" },
   },
   externalsPresets: { node: true },

--- a/ps5-mqtt/server/src/playactor/__tests__/client.test.ts
+++ b/ps5-mqtt/server/src/playactor/__tests__/client.test.ts
@@ -28,6 +28,17 @@ const CHECK_CMD =
   ` --timeout 15000 --connect-timeout 10000 --no-open-urls --no-auth` +
   ` -c ${CREDENTIAL_PATH}`
 
+// Every playactor invocation must carry the preload shim in NODE_OPTIONS
+// (see ../preload.ts); the exact path differs between ts-jest (src/) and the
+// built bundle (dist/), so only the file name is pinned here.
+const execOptions = (timeout: number) => ({
+  silent: true,
+  timeout,
+  env: expect.objectContaining({
+    NODE_OPTIONS: expect.stringContaining("playactor-preload.js"),
+  }),
+})
+
 describe("PlayactorClient", () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -42,10 +53,7 @@ describe("PlayactorClient", () => {
       mockExec.mockReturnValue(execResult({ code: 0, stdout: "ok" }))
 
       await expect(client.wake(IP)).resolves.toBeUndefined()
-      expect(mockExec).toHaveBeenCalledWith(WAKE_CMD, {
-        silent: true,
-        timeout: 5000,
-      })
+      expect(mockExec).toHaveBeenCalledWith(WAKE_CMD, execOptions(5000))
     })
 
     test("includes the --pass-code fragment when a passcode is configured", async () => {
@@ -62,7 +70,7 @@ describe("PlayactorClient", () => {
           ` --timeout 5000 --connect-timeout 5000 --no-open-urls --no-auth` +
           ` --pass-code '1234'` +
           ` -c ${CREDENTIAL_PATH}`,
-        { silent: true, timeout: 5000 },
+        execOptions(5000),
       )
     })
 
@@ -85,7 +93,7 @@ describe("PlayactorClient", () => {
         `playactor wake --ip ${IP}` +
           ` --timeout 5000 --connect-timeout 5000 --no-open-urls --no-auth` +
           ` --ps5 -c ${CREDENTIAL_PATH}`,
-        { silent: true, timeout: 5000 },
+        execOptions(5000),
       )
     })
 
@@ -102,10 +110,7 @@ describe("PlayactorClient", () => {
       mockExec.mockReturnValue(execResult({ code: 0, stdout: "ok" }))
 
       await expect(client.standby(IP)).resolves.toBeUndefined()
-      expect(mockExec).toHaveBeenCalledWith(STANDBY_CMD, {
-        silent: true,
-        timeout: 25000,
-      })
+      expect(mockExec).toHaveBeenCalledWith(STANDBY_CMD, execOptions(25000))
     })
 
     test("throws the raw stderr when playactor writes to stderr", async () => {
@@ -127,7 +132,7 @@ describe("PlayactorClient", () => {
         `playactor standby --ip ${IP}` +
           ` --timeout 10000 --connect-timeout 10000 --no-open-urls --no-auth` +
           ` --ps5 -c ${CREDENTIAL_PATH}`,
-        { silent: true, timeout: 25000 },
+        execOptions(25000),
       )
     })
 
@@ -155,10 +160,7 @@ describe("PlayactorClient", () => {
       )
 
       await expect(client.check(IP)).resolves.toEqual(makeDevice())
-      expect(mockExec).toHaveBeenCalledWith(CHECK_CMD, {
-        silent: true,
-        timeout: 15000,
-      })
+      expect(mockExec).toHaveBeenCalledWith(CHECK_CMD, execOptions(15000))
     })
 
     test("throws an Error when exit code > 1 and stderr is present", async () => {

--- a/ps5-mqtt/server/src/playactor/__tests__/preload.test.ts
+++ b/ps5-mqtt/server/src/playactor/__tests__/preload.test.ts
@@ -1,0 +1,56 @@
+import http from "http"
+import net from "net"
+
+// https://github.com/FunkeyFlo/ps5-mqtt/issues/678
+// What playactor does for standby: keep-alive request, then take over the
+// response socket while the console keeps talking on it. Without the shim,
+// Node's free-socket data guard closes the socket on those bytes.
+describe("playactor preload shim", () => {
+  const OriginalAgent = http.Agent
+  let server: net.Server
+
+  beforeAll(async () => {
+    jest.requireActual("../preload")
+    server = net.createServer((socket) => {
+      socket.once("data", () => {
+        socket.write(
+          "HTTP/1.1 200 OK\r\nConnection: keep-alive\r\nContent-Length: 0\r\n\r\n",
+        )
+        setTimeout(() => socket.write("login-result"), 100)
+      })
+    })
+    await new Promise<void>((done) => server.listen(0, "127.0.0.1", done))
+  })
+
+  afterAll(() => {
+    http.Agent = OriginalAgent
+    server.close()
+  })
+
+  test("a taken-over keep-alive socket still receives data sent after the response", async () => {
+    const { port } = server.address() as net.AddressInfo
+    const agent = new http.Agent({ keepAlive: true })
+
+    const received = new Promise<string>((resolve, reject) => {
+      const req = http.get({ host: "127.0.0.1", port, agent }, (res) => {
+        res.resume()
+        // playactor only takes over after its HTTP client resolves, i.e.
+        // after Node has already handed the socket back to the agent.
+        res.on("end", () =>
+          setImmediate(() => {
+            const socket = req.socket as net.Socket
+            socket.removeAllListeners()
+            socket.on("data", (chunk) => resolve(chunk.toString()))
+            socket.on("close", () =>
+              reject(new Error("socket closed before the data arrived")),
+            )
+          }),
+        )
+      })
+      req.on("error", reject)
+    })
+
+    await expect(received).resolves.toBe("login-result")
+    agent.destroy()
+  })
+})

--- a/ps5-mqtt/server/src/playactor/client.ts
+++ b/ps5-mqtt/server/src/playactor/client.ts
@@ -1,4 +1,5 @@
 import createDebugger from "debug"
+import path from "path"
 import sh from "shelljs"
 
 import type { Device } from "../redux/types"
@@ -22,6 +23,20 @@ const STANDBY_CONNECT_TIMEOUT_MS = 10000
 const STANDBY_SHELLJS_TIMEOUT_MS = 25000
 
 const WAKE_SHELLJS_TIMEOUT_MS = 5000
+
+// Every playactor child gets the shim from ./preload.ts (built next to
+// index.js). Appended to NODE_OPTIONS, not replacing it: under Yarn PnP it
+// already carries the PnP loader the child needs to resolve `playactor`.
+// https://github.com/FunkeyFlo/ps5-mqtt/issues/678
+const PLAYACTOR_ENV: NodeJS.ProcessEnv = {
+  ...process.env,
+  NODE_OPTIONS: [
+    process.env.NODE_OPTIONS,
+    `--require "${path.join(__dirname, "playactor-preload.js")}"`,
+  ]
+    .filter(Boolean)
+    .join(" "),
+}
 
 /**
  * Thin wrapper around the `playactor` CLI. Centralizes the command building,
@@ -74,6 +89,7 @@ export function createPlayactorClient({
     const { code, stdout, stderr } = sh.exec(command, {
       silent: true,
       timeout: shelljsTimeoutMillis,
+      env: PLAYACTOR_ENV,
     })
 
     if (stderr) {
@@ -101,16 +117,14 @@ export function createPlayactorClient({
     },
 
     async standby(ip: string): Promise<void> {
-      await runPowerCommand(
-        buildStandbyCommand(ip),
-        STANDBY_SHELLJS_TIMEOUT_MS,
-      )
+      await runPowerCommand(buildStandbyCommand(ip), STANDBY_SHELLJS_TIMEOUT_MS)
     },
 
     async check(ip: string): Promise<Device> {
       const { code, stdout, stderr } = sh.exec(buildCheckCommand(ip), {
         silent: true,
         timeout: 15000,
+        env: PLAYACTOR_ENV,
       })
 
       if (code > 1 && stderr) {

--- a/ps5-mqtt/server/src/playactor/preload.ts
+++ b/ps5-mqtt/server/src/playactor/preload.ts
@@ -1,0 +1,17 @@
+// Preloaded into every `playactor` child process (NODE_OPTIONS --require, see
+// ./client.ts). playactor takes over the keep-alive socket of its sess/ctrl
+// request as the Remote Play control channel; Node >= 22.23 destroys a pooled
+// keep-alive socket as soon as unsolicited data arrives on it, so `standby`
+// silently died on the PS5's first reply. Never pool sockets in this process.
+// https://github.com/FunkeyFlo/ps5-mqtt/issues/678
+import http from "http"
+
+const OriginalAgent = http.Agent
+
+http.Agent = class extends OriginalAgent {
+  constructor(options?: http.AgentOptions) {
+    super(options)
+    this.removeAllListeners("free")
+    this.on("free", () => {})
+  }
+}


### PR DESCRIPTION
Fixes #678

## Problem

On the 1.7.0 images `wake` works but `standby` never puts the PS5 to sleep, while HA is told `STANDBY` succeeded. The console flashes "Remote Play connected / disconnected" and stays awake.

The image ships Node v22.23.2, which (like current 24.x/25.x) carries the *free-socket data guard* security fix in `_http_agent.js` (hackerone 3582376): once a keep-alive socket is parked in the agent's free pool, any unsolicited data on it destroys the socket. playactor opens the Remote Play control channel by issuing `/sie/ps5/rp/sess/ctrl` through a keep-alive `http.Agent` and then taking over the response socket as a raw stream. By then Node has already pooled it, so the PS5's first reply (the login result) triggers the guard, the socket is destroyed with only a `close` event, playactor's pending promise never settles, the process exits 0 with empty output, and `runPowerCommand` reports success. Full trace, including the `freeSocketOnReadGuard` stack, is in #678.

## Fix

Preload a tiny, dependency-free shim into every playactor child process via `NODE_OPTIONS=--require` (`ps5-mqtt/server/src/playactor/preload.ts`, built by rspack as `dist/playactor-preload.js`). It subclasses `http.Agent` so the default `"free"` handler, which both pools the socket and installs the guard, is replaced by a no-op (10 lines of code). `http.globalAgent` is untouched; only agents constructed inside the playactor process are affected, and playactor closes its control socket itself.

`client.ts` now passes an `env` to every `sh.exec` with the shim appended (not replacing) to `NODE_OPTIONS`, since under Yarn PnP it already carries the PnP loader the child needs.

### Why not patch playactor's `node_modules`?

Both runtime Dockerfiles install dependencies with plain `npm install` from the packaged `package.json`, and the Home Assistant add-on image runs a *globally* installed playactor (`npm i -g playactor`). A `patch-package`/`yarn patch` approach would not reach either. The env-based preload works for the standalone image, the add-on image, `yarn start` under PnP, and survives playactor version bumps. playactor upstream appears unmaintained (last activity 2022).

## Verification

- One regression test, `preload.test.ts`: a local TCP server answers a keep-alive request, then pushes bytes on the same connection; the taken-over socket must receive them. Without the shim it fails on any Node with the guard (`socket closed before the data arrived`), with the shim it passes.
- Real hardware (PS5 system 13.60, `ghcr.io/funkeyflo/ps5-mqtt:1.7.0`, host network): in a throwaway container from the unmodified image, `playactor standby` without the shim exits 0 and the console stays `AWAKE`; the same command with `NODE_OPTIONS="--require /t/playactor-preload.js"` exits 0 and the console reports `STANDBY` (also confirmed via the retained MQTT state).
- `yarn format/check`, `yarn typecheck`, `yarn lint`, `yarn test/unit` (68 tests, 12 suites) pass locally on Node 26.7 (which has the guard). I could not run `yarn test/e2e` locally (no Docker daemon for the mosquitto dev service); it should run in CI. Note the e2e fake `playactor` is a Node script, so it loads the shim too; that path is exercised by the e2e suite.

## Notes

- A follow-up could make `runPowerCommand` re-check the device state after a `standby` that exits 0 with empty output, so a future silent playactor failure is at least surfaced instead of reported as success.
- No CHANGELOG edit, as it is generated at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
